### PR TITLE
feat: open links from widget in new pages target=_blank

### DIFF
--- a/templates/widget/index.html
+++ b/templates/widget/index.html
@@ -33,12 +33,14 @@
           <p class="widget__mcaptcha-brand-name">mCaptcha</p>
         </a>
         <div class="widget__mcaptcha-info-container">
-			<a class="widget__mcaptcha-info-link"
-			 href="<.= crate::PKG_HOMEPAGE .><.= crate::PAGES.privacy .>">
+		  <a class="widget__mcaptcha-info-link"
+			target="_blank"
+			href="<.= crate::PKG_HOMEPAGE .><.= crate::PAGES.privacy .>">
             Privacy
           </a>
 		  <a class="widget__mcaptcha-info-link"
-			  href="<.= crate::PKG_HOMEPAGE .><.= crate::PAGES.security .>">
+		  	target="_blank"
+			href="<.= crate::PKG_HOMEPAGE .><.= crate::PAGES.security .>">
             Terms
           </a>
         </div>


### PR DESCRIPTION
If the widget is added as iframe in a website this links should not open in the iframe. They should open in a new tab instead. Would be nice if you consider a pull and add it to your project.