### PR TITLE
Allow `PORT` environment to be not set

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -170,7 +170,7 @@ impl Settings {
             Ok(val) => {
                 s.set("server.port", val).unwrap();
             }
-            Err(e) => warn!("couldn't interpret PORT: {}", e),
+            _ => (),
         }
 
         match env::var("DATABASE_URL") {


### PR DESCRIPTION
- It's quite weird to require the `PORT` environment to be set, when it already can be set via the config file.