### PR TITLE
Encode connection URL to database

### DIFF
--- a/db/db-sqlx-maria/Cargo.toml
+++ b/db/db-sqlx-maria/Cargo.toml
@@ -13,6 +13,7 @@ async-trait = "0.1.51"
 db-core = {path = "../db-core"}
 futures = "0.3.15"
 sqlx = { version = "0.5.13", features = [ "runtime-actix-rustls", "mysql", "time", "offline" ] }
+urlencoding = "2.1.2"
 
 [dev-dependencies]
 actix-rt = "2"

--- a/db/db-sqlx-maria/src/lib.rs
+++ b/db/db-sqlx-maria/src/lib.rs
@@ -68,14 +68,13 @@ impl Connect for ConnectionOptions {
     async fn connect(self) -> DBResult<Self::Pool> {
         let pool = match self {
             Self::Fresh(fresh) => {
-                let mut connect_options =
-                    sqlx::mysql::MySqlConnectOptions::from_str(&fresh.url).unwrap();
+                let mut connect_options = sqlx::mysql::MySqlConnectOptions::from_str(
+                    &urlencoding::encode(&fresh.url),
+                )
+                .unwrap();
                 if fresh.disable_logging {
                     connect_options.disable_statement_logging();
                 }
-                sqlx::mysql::MySqlConnectOptions::from_str(&fresh.url)
-                    .unwrap()
-                    .disable_statement_logging();
                 fresh
                     .pool_options
                     .connect_with(connect_options)

--- a/db/db-sqlx-postgres/Cargo.toml
+++ b/db/db-sqlx-postgres/Cargo.toml
@@ -13,6 +13,7 @@ async-trait = "0.1.51"
 db-core = {path = "../db-core"}
 futures = "0.3.15"
 sqlx = { version = "0.5.13", features = [ "runtime-actix-rustls", "postgres", "time", "offline" ] }
+urlencoding = "2.1.2"
 
 [dev-dependencies]
 actix-rt = "2"

--- a/db/db-sqlx-postgres/src/lib.rs
+++ b/db/db-sqlx-postgres/src/lib.rs
@@ -68,14 +68,13 @@ impl Connect for ConnectionOptions {
     async fn connect(self) -> DBResult<Self::Pool> {
         let pool = match self {
             Self::Fresh(fresh) => {
-                let mut connect_options =
-                    sqlx::postgres::PgConnectOptions::from_str(&fresh.url).unwrap();
+                let mut connect_options = sqlx::postgres::PgConnectOptions::from_str(
+                    &urlencoding::encode(&fresh.url),
+                )
+                .unwrap();
                 if fresh.disable_logging {
                     connect_options.disable_statement_logging();
                 }
-                sqlx::postgres::PgConnectOptions::from_str(&fresh.url)
-                    .unwrap()
-                    .disable_statement_logging();
                 fresh
                     .pool_options
                     .connect_with(connect_options)


### PR DESCRIPTION
- If you have a database password that contains characters like `#` or `*`, sqlx will error about a InvalidPort, this is due to not encoding the url. [See issue on sqlx](https://github.com/launchbadge/sqlx/issues/1624).
- Removed useless statements.