### PR TITLE
debug: first run firefox tests

### DIFF
--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -28,8 +28,8 @@ git clone https://github.com/mCaptcha/integration .
 if is_ci
 then
 	yarn install
-	xvfb-run --auto-servernum npm run test.chrome
 	xvfb-run --auto-servernum npm run test.firefox
+	xvfb-run --auto-servernum npm run test.chrome
 else
 	yarn install
 	npx nightwatch ./test/mCaptcha.ts


### PR DESCRIPTION
For some reason, running integration tests with Firefox first and then Chromium doesn't break the CI