### PR TITLE
Change license

### DIFF
--- a/docs/openapi/package.json
+++ b/docs/openapi/package.json
@@ -11,7 +11,7 @@
     "type": "git",
     "url": "git+https://github.com/mCaptcha/mCaptcha.git"
   },
-  "license": "AGPL3",
+  "license": "AGPL-3.0-or-later",
   "bugs": {
     "url": "https://github.com/mCaptcha/mCaptcha/issues"
   },


### PR DESCRIPTION
`AGPL3` isn't a valid SPDX identifier, but `AGPL-3.0-or-later` is. See https://spdx.org/licenses/