### PR TITLE
fix: create max_recorded nonce for existing captcha configs

### DIFF
--- a/db/db-sqlx-maria/.sqlx/query-9def82dcec9c8d477824182bb2f71044cc264cf2073ab4f60a0000b435ed0f0b.json
+++ b/db/db-sqlx-maria/.sqlx/query-9def82dcec9c8d477824182bb2f71044cc264cf2073ab4f60a0000b435ed0f0b.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "MySQL",
+  "query": "INSERT INTO\n                    mcaptcha_track_nonce (level_id, nonce)\n                VALUES  ((\n                    SELECT\n                        level_id\n                    FROM\n                        mcaptcha_levels\n                    WHERE\n                        config_id = (SELECT config_id FROM mcaptcha_config WHERE captcha_key =?)\n                    AND\n                        difficulty_factor = ?\n                    ), ?);",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 3
+    },
+    "nullable": []
+  },
+  "hash": "9def82dcec9c8d477824182bb2f71044cc264cf2073ab4f60a0000b435ed0f0b"
+}

--- a/db/db-sqlx-maria/src/lib.rs
+++ b/db/db-sqlx-maria/src/lib.rs
@@ -1163,7 +1163,12 @@ impl MCDatabase for Database {
             nonce: i32,
         }
 
-        let res = sqlx::query_as!(
+        async fn inner_get_max_nonce(
+            pool: &MySqlPool,
+            captcha_key: &str,
+            difficulty_factor: u32,
+        ) -> DBResult<X> {
+            sqlx::query_as!(
                 X,
                 "SELECT nonce FROM mcaptcha_track_nonce
                 WHERE level_id =  (
@@ -1179,10 +1184,40 @@ impl MCDatabase for Database {
                 &captcha_key,
                 difficulty_factor as i32,
             )
-                .fetch_one(&self.pool).await
+                .fetch_one(pool).await
+                .map_err(|e| map_row_not_found_err(e, DBError::CaptchaNotFound))
+        }
+
+        let res = inner_get_max_nonce(&self.pool, captcha_key, difficulty_factor).await;
+        if let Err(DBError::CaptchaNotFound) = res {
+            sqlx::query!(
+                "INSERT INTO
+                    mcaptcha_track_nonce (level_id, nonce)
+                VALUES  ((
+                    SELECT
+                        level_id
+                    FROM
+                        mcaptcha_levels
+                    WHERE
+                        config_id = (SELECT config_id FROM mcaptcha_config WHERE captcha_key =?)
+                    AND
+                        difficulty_factor = ?
+                    ), ?);",
+                &captcha_key,
+                difficulty_factor as i32,
+                0,
+            )
+            .execute(&self.pool)
+            .await
                 .map_err(|e| map_row_not_found_err(e, DBError::CaptchaNotFound))?;
 
-        Ok(res.nonce as u32)
+            let res =
+                inner_get_max_nonce(&self.pool, captcha_key, difficulty_factor).await?;
+            Ok(res.nonce as u32)
+        } else {
+            let res = res?;
+            Ok(res.nonce as u32)
+        }
     }
 }
 

--- a/db/db-sqlx-postgres/.sqlx/query-e0088cf77c1c3a0184f35d1899a6168023fba021adf281cf1c8f9e8ccfe3a03e.json
+++ b/db/db-sqlx-postgres/.sqlx/query-e0088cf77c1c3a0184f35d1899a6168023fba021adf281cf1c8f9e8ccfe3a03e.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO\n                    mcaptcha_track_nonce (level_id, nonce)\n                VALUES  ((\n                    SELECT\n                        level_id\n                    FROM\n                        mcaptcha_levels\n                    WHERE\n                        config_id = (SELECT config_id FROM mcaptcha_config WHERE key = ($1))\n                    AND\n                        difficulty_factor = $2\n                    ), $3);",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int4",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "e0088cf77c1c3a0184f35d1899a6168023fba021adf281cf1c8f9e8ccfe3a03e"
+}


### PR DESCRIPTION
`get_config` returns `CaptchaNotFound` for existing captcha configurations which don't have max recorded nonce records. This patch fixes it.