### PR TITLE
feat: new dashboard page to show percentile scores on PoW performance analysis records

### DIFF
--- a/db/db-sqlx-maria/src/lib.rs
+++ b/db/db-sqlx-maria/src/lib.rs
@@ -43,7 +43,6 @@ pub mod dev {
     pub use super::errors::*;
     pub use super::Database;
     pub use db_core::dev::*;
-    pub use prelude::*;
     pub use sqlx::Error;
 }
 

--- a/db/db-sqlx-postgres/src/lib.rs
+++ b/db/db-sqlx-postgres/src/lib.rs
@@ -43,7 +43,6 @@ pub mod dev {
     pub use super::errors::*;
     pub use super::Database;
     pub use db_core::dev::*;
-    pub use prelude::*;
     pub use sqlx::Error;
 }
 

--- a/src/pages/panel/mod.rs
+++ b/src/pages/panel/mod.rs
@@ -10,6 +10,7 @@ use sailfish::TemplateOnce;
 mod notifications;
 mod settings;
 pub mod sitekey;
+mod utils;
 
 use db_core::Captcha;
 
@@ -47,18 +48,21 @@ pub fn services(cfg: &mut actix_web::web::ServiceConfig) {
     cfg.service(panel);
     settings::services(cfg);
     sitekey::services(cfg);
+    utils::services(cfg);
     cfg.service(notifications::notifications);
 }
 
 pub mod routes {
     use super::settings::routes::Settings;
     use super::sitekey::routes::Sitekey;
+    use super::utils::routes::Utils;
 
     pub struct Panel {
         pub home: &'static str,
         pub sitekey: Sitekey,
         pub notifications: &'static str,
         pub settings: Settings,
+        pub utils: Utils,
     }
 
     impl Panel {
@@ -68,10 +72,11 @@ pub mod routes {
                 sitekey: Sitekey::new(),
                 notifications: "/notifications",
                 settings: Settings::new(),
+                utils: Utils::new(),
             }
         }
 
-        pub const fn get_sitemap() -> [&'static str; 5] {
+        pub const fn get_sitemap() -> [&'static str; 6] {
             const PANEL: Panel = Panel::new();
             const S: [&str; 2] = Sitekey::get_sitemap();
 
@@ -81,6 +86,7 @@ pub mod routes {
                 S[0],
                 S[1],
                 Settings::get_sitemap()[0],
+                Utils::get_sitemap()[0],
             ]
         }
     }

--- a/src/pages/panel/utils.rs
+++ b/src/pages/panel/utils.rs
@@ -1,0 +1,280 @@
+// Copyright (C) 2024  Aravinth Manivannan <realaravinth@batsense.net>
+// SPDX-FileCopyrightText: 2023 Aravinth Manivannan <realaravinth@batsense.net>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use actix_identity::Identity;
+use actix_web::{web, HttpResponse, Responder};
+use sailfish::TemplateOnce;
+
+use crate::api::v1::stats::{percentile_bench_runner, PercentileReq, PercentileResp};
+use crate::errors::PageResult;
+use crate::pages::auth::sudo::SudoPage;
+use crate::AppData;
+
+pub mod routes {
+    pub struct Utils {
+        pub percentile: &'static str,
+    }
+
+    impl Utils {
+        pub const fn new() -> Self {
+            Utils {
+                percentile: "/utils/percentile",
+            }
+        }
+
+        pub const fn get_sitemap() -> [&'static str; 1] {
+            const S: Utils = Utils::new();
+            [S.percentile]
+        }
+    }
+}
+
+pub fn services(cfg: &mut actix_web::web::ServiceConfig) {
+    cfg.service(get_percentile);
+    cfg.service(post_percentile);
+}
+
+const PAGE: &str = "Difficulty factor statistics";
+
+#[derive(TemplateOnce, Clone)]
+#[template(path = "panel/utils/percentile/index.html")]
+pub struct PercentilePage {
+    time: Option<u32>,
+    percentile: Option<f64>,
+    difficulty_factor: Option<u32>,
+}
+
+#[my_codegen::get(
+    path = "crate::PAGES.panel.utils.percentile",
+    wrap = "crate::pages::get_middleware()"
+)]
+async fn get_percentile(id: Identity) -> PageResult<impl Responder> {
+    let data = PercentilePage {
+        time: None,
+        percentile: None,
+        difficulty_factor: None,
+    };
+
+    let body = data.render_once().unwrap();
+    Ok(HttpResponse::Ok()
+        .content_type("text/html; charset=utf-8")
+        .body(body))
+}
+
+#[my_codegen::post(
+    path = "crate::PAGES.panel.utils.percentile",
+    wrap = "crate::pages::get_middleware()"
+)]
+async fn post_percentile(
+    data: AppData,
+    id: Identity,
+    payload: web::Form<PercentileReq>,
+) -> PageResult<impl Responder> {
+    let resp = percentile_bench_runner(&data, &payload).await?;
+    let page = PercentilePage {
+        time: Some(payload.time),
+        percentile: Some(payload.percentile),
+        difficulty_factor: resp.difficulty_factor,
+    };
+
+    let body = page.render_once().unwrap();
+    Ok(HttpResponse::Ok()
+        .content_type("text/html; charset=utf-8")
+        .body(body))
+}
+
+#[cfg(test)]
+mod tests {
+    use actix_web::{http::StatusCode, test, web::Bytes, App};
+
+    use super::*;
+    use crate::api::v1::services;
+    use crate::*;
+
+    #[actix_rt::test]
+    async fn page_stats_bench_work_pg() {
+        let data = crate::tests::pg::get_data().await;
+        page_stats_bench_work(data).await;
+    }
+
+    #[actix_rt::test]
+    async fn page_stats_bench_work_maria() {
+        let data = crate::tests::maria::get_data().await;
+        page_stats_bench_work(data).await;
+    }
+
+    async fn page_stats_bench_work(data: ArcData) {
+        use crate::tests::*;
+
+        const NAME: &str = "pagebenchstatsuesr";
+        const EMAIL: &str = "pagebenchstatsuesr@testadminuser.com";
+        const PASSWORD: &str = "longpassword2";
+
+        const DEVICE_USER_PROVIDED: &str = "foo";
+        const DEVICE_SOFTWARE_RECOGNISED: &str = "Foobar.v2";
+        const THREADS: i32 = 4;
+
+        let data = &data;
+        {
+            delete_user(&data, NAME).await;
+        }
+
+        register_and_signin(data, NAME, EMAIL, PASSWORD).await;
+        // create captcha
+        let (_, signin_resp, key) = add_levels_util(data, NAME, PASSWORD).await;
+        let app = get_app!(data).await;
+        let cookies = get_cookie!(signin_resp);
+
+        let page = 1;
+        let tmp_id = uuid::Uuid::new_v4();
+        let download_rotue = V1_API_ROUTES
+            .survey
+            .get_download_route(&tmp_id.to_string(), page);
+
+        let download_req = test::call_service(
+            &app,
+            test::TestRequest::get().uri(&download_rotue).to_request(),
+        )
+        .await;
+        assert_eq!(download_req.status(), StatusCode::NOT_FOUND);
+
+        data.db
+            .analytics_create_psuedo_id_if_not_exists(&key.key)
+            .await
+            .unwrap();
+
+        let psuedo_id = data
+            .db
+            .analytics_get_psuedo_id_from_capmaign_id(&key.key)
+            .await
+            .unwrap();
+
+        for i in 1..6 {
+            println!("[{i}] Saving analytics");
+            let analytics = db_core::CreatePerformanceAnalytics {
+                time: i,
+                difficulty_factor: i,
+                worker_type: "wasm".into(),
+            };
+            data.db.analysis_save(&key.key, &analytics).await.unwrap();
+        }
+
+        let msg = PercentileReq {
+            time: 1,
+            percentile: 99.00,
+        };
+        let resp = test::call_service(
+            &app,
+            post_request!(&msg, V1_API_ROUTES.stats.percentile_benches).to_request(),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let resp: PercentileResp = test::read_body_json(resp).await;
+
+        assert!(resp.difficulty_factor.is_none());
+
+        let msg = PercentileReq {
+            time: 1,
+            percentile: 100.00,
+        };
+
+        let resp = test::call_service(
+            &app,
+            post_request!(&msg, V1_API_ROUTES.stats.percentile_benches).to_request(),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let resp: PercentileResp = test::read_body_json(resp).await;
+
+        // start
+        let percentile_resp = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri(&crate::PAGES.panel.utils.percentile)
+                .cookie(cookies.clone())
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(percentile_resp.status(), StatusCode::OK);
+
+        let body: Bytes = test::read_body(percentile_resp).await;
+        let body = String::from_utf8(body.to_vec()).unwrap();
+
+        assert!(body.contains("Maximum time taken"));
+
+        let percentile_resp = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri(&crate::PAGES.panel.utils.percentile)
+                .cookie(cookies.clone())
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(percentile_resp.status(), StatusCode::OK);
+
+        let body: Bytes = test::read_body(percentile_resp).await;
+        let body = String::from_utf8(body.to_vec()).unwrap();
+
+        assert!(body.contains("Maximum time taken"));
+
+        // end
+        // start post
+
+        let msg = PercentileReq {
+            time: 1,
+            percentile: 99.00,
+        };
+
+        let percentile_resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri(&crate::PAGES.panel.utils.percentile)
+                .set_form(&msg)
+                .cookie(cookies.clone())
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(percentile_resp.status(), StatusCode::OK);
+
+        let body: Bytes = test::read_body(percentile_resp).await;
+        let body = String::from_utf8(body.to_vec()).unwrap();
+
+        assert!(body.contains(
+            "Not enough inputs to compute statistics. Please try again later"
+        ));
+        assert!(body.contains(&1.to_string()));
+        assert!(body.contains(&99.00.to_string()));
+        // end post
+
+        // start post
+
+        let msg = PercentileReq {
+            time: 2,
+            percentile: 100.00,
+        };
+
+        let percentile_resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri(&crate::PAGES.panel.utils.percentile)
+                .set_form(&msg)
+                .cookie(cookies.clone())
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(percentile_resp.status(), StatusCode::OK);
+
+        let body: Bytes = test::read_body(percentile_resp).await;
+        let body = String::from_utf8(body.to_vec()).unwrap();
+
+        assert!(body.contains("Difficulty factor: 2"));
+        assert!(body.contains(&2.to_string()));
+        assert!(body.contains(&100.00.to_string()));
+    }
+}

--- a/templates/panel/navbar/index.html
+++ b/templates/panel/navbar/index.html
@@ -5,15 +5,15 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
 <nav class="secondary-menu">
-	<input type="checkbox" class="nav-toggle" id="nav-toggle" >
+  <input type="checkbox" class="nav-toggle" id="nav-toggle" >
   <div class="secondary-menu__heading">
-	  <a  class="novisit" href="/">
-		  <img class="secondary-menu__logo" src="<.= crate::MCAPTCHA_TRANS_ICON.0 .>" alt="<.= crate::MCAPTCHA_TRANS_ICON.1 .>" />
+    <a  class="novisit" href="/">
+      <img class="secondary-menu__logo" src="<.= crate::MCAPTCHA_TRANS_ICON.0 .>" alt="<.= crate::MCAPTCHA_TRANS_ICON.1 .>" />
     </a>
     <a href="/" class="secondary-menu__brand-name">
       mCaptcha
     </a>
-	<label class="nav__hamburger-menu"for="nav-toggle">
+    <label class="nav__hamburger-menu"for="nav-toggle">
       <span></span>
       <span></span>
       <span></span>
@@ -21,7 +21,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
   </div>
   <ul class="secondary-menu__list">
     <li class="secondary-menu__item">
-        <a class="secondary-menu__item-link" href="<.= crate::PAGES.home .>">
+      <a class="secondary-menu__item-link" href="<.= crate::PAGES.home .>">
         <img class="secondary-menu__icon" src="<.= crate::HOME.0 .>" alt="<.= crate::HOME.1 .>" />
         <div class="secondary-menu__item-name">
           Overview
@@ -29,10 +29,18 @@ SPDX-License-Identifier: AGPL-3.0-or-later
       </a>
     </li>
     <li class="secondary-menu__item">
-        <a class="secondary-menu__item-link" href="<.= crate::PAGES.panel.sitekey.list .>">
+      <a class="secondary-menu__item-link" href="<.= crate::PAGES.panel.sitekey.list .>">
         <img class="secondary-menu__icon" src="<.= crate::KEY.0 .>" alt="<.= crate::KEY.1 .>" />
         <div class="secondary-menu__item-name">
           Site Keys
+        </div>
+      </a>
+    </li>
+    <li class="secondary-menu__item">
+      <a class="secondary-menu__item-link" href="<.= crate::PAGES.panel.utils.percentile .>">
+        <img class="secondary-menu__icon" src="<.= crate::BAR_CHART.0 .>" alt="<.= crate::BAR_CHART.1 .>" />
+        <div class="secondary-menu__item-name">
+          Statistics
         </div>
       </a>
     </li>

--- a/templates/panel/utils/percentile/index.html
+++ b/templates/panel/utils/percentile/index.html
@@ -1,0 +1,67 @@
+<!--
+SPDX-FileCopyrightText: 2023 Aravinth Manivannan <realaravinth@batsense.net>
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<. include!("../../../components/headers/index.html"); .> 
+<. include!("../../navbar/index.html"); .>
+<div class="tmp-layout">
+<. include!("../../header/index.html"); .>
+<main class="panel-main">
+  <. include!("../../help-banner/index.html"); .>
+  <!-- Main content container -->
+  <div class="inner-container">
+  <div class="sitekey-form" action="<.= crate::V1_API_ROUTES.captcha.create .>" method="post">
+	<h1 class="form__title">
+		<.= PAGE .>
+	</h1>
+
+      <form class="settings__form" id="utils_percentile-form"
+        action="<.= crate::PAGES.panel.utils.percentile .>" method="post">
+
+        <. if let Some(difficulty_factor) = difficulty_factor { .>
+            <legend class="sitekey__level-title">
+              <p>Difficulty factor: <.= difficulty_factor .></p>
+            </legend>
+          <. } else { .>
+            <. if time.is_some() && percentile.is_some() { .>
+            <legend class="sitekey__level-title">
+              <p>Not enough inputs to compute statistics. Please try again later</p>
+            </legend>
+            <. } .>
+          <. } .>
+
+
+        <label class="settings-form__label" for="time">
+          Maximum time taken to solve CAPTCHA (in seconds)
+          <input
+            class="settings-form__input"
+            type="number"
+            name="time"
+            required
+            id="time"
+            <. if let Some(time) = time { .>
+              value="<.= time .>"
+            <. } .>
+          />
+        </label>
+        <label class="settings-form__label" for="percentile">
+          Percentile of requests coming under time limit
+          <input
+            class="settings-form__input"
+            type="number"
+            name="percentile"
+            required
+            id="percentile"
+            <. if let Some(percentile) = percentile { .>
+                value="<.= percentile .>"
+            <. } .>
+          />
+        </label>
+        <button class="settings__submit-btn" type="submit">Search</button>
+      </form>
+  </div>
+  </div>
+  <!-- end of container -->
+<. include!("../../../components/footers.html"); .>


### PR DESCRIPTION
Added new page to the dashboard to explore PoW performance records stored on the instance

## Screenshot

![image](https://github.com/mCaptcha/mCaptcha/assets/33521410/090fcba1-86f3-4453-b75d-41bf7b7da87c)
