### PR TITLE
feat: list all env vars and load in docker-compose

### DIFF
--- a/.env.docker-compose
+++ b/.env.docker-compose
@@ -1,0 +1,43 @@
+MCAPTCHA_debug=false
+MCAPTCHA_commercial=false
+MCAPTCHA_source_code=https://github.com/mCaptcha/mCaptcha
+MCAPTCHA_allow_registration=false
+MCAPTCHA_allow_demo=false
+
+# database
+DATABASE_URL=postgres://postgres:password@mcaptcha_postgres:5432/postgres
+MCAPTCHA_database_POOL=4
+
+# redis
+MCAPTCHA_redis_URL=redis://mcaptcha_redis
+MCAPTCHA_redis_POOL=4
+
+# server
+PORT=7001
+MCAPTCHA_server_DOMAIN=localhost
+MCAPTCHA__server_COOKIE_SECRET=pleasereplacethiswithrandomstring # PLEASE SET RANDOM STRING. MIN LENGTH=32
+MCAPTCHA__server_IP= 0.0.0.0
+
+
+# captcha
+MCAPTCHA_captcha_SALT=pleasereplacethiswithrandomstring # PLEASE SET RANDOM STRING. MIN LENGTH=32
+MCAPTCHA_captcha_GC=30
+MCAPTCHA_captcha_RUNNERS=4
+MCAPTCHA_captcha_QUEUE_LENGTH=2000
+MCAPTCHA_captcha_ENABLE_STATS=true
+MCAPTCHA_captcha_DEFAULT_DIFFICULTY_STRATEGY_avg_traffic_difficulty=50000 # almost instant solution
+MCAPTCHA_captcha_DEFAULT_DIFFICULTY_STRATEGY_broke_my_site_traffic_difficulty=3000000 # roughly 1.5s
+MCAPTCHA_captcha_DEFAULT_DIFFICULTY_STRATEGY_peak_sustainable_traffic_difficulty=5000000  # greater than 3.5s
+MCAPTCHA_captcha_DEFAULT_DIFFICULTY_STRATEGY_duration=30 # cooldown period in seconds
+MCAPTCHA_captcha_DEFAULT_DIFFICULTY_STRATEGY_avg_traffic_time=1 # almost instant solution
+MCAPTCHA_captcha_DEFAULT_DIFFICULTY_STRATEGY_peak_sustainable_traffic_time=3
+MCAPTCHA_captcha_DEFAULT_DIFFICULTY_STRATEGY_broke_my_site_traffic_time=5
+
+
+# SMTP 
+#MCAPTCHA_smtp_FROM=
+#MCAPTCHA_smtp_REPLY=
+#MCAPTCHA_smtp_URL=
+#MCAPTCHA_smtp_USERNAME=
+#MCAPTCHA_smtp_PASSWORD=
+#MCAPTCHA_smtp_PORT=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,11 +9,8 @@ services:
     image: mcaptcha/mcaptcha:latest
     ports:
       - 7000:7000
-    environment:
-      DATABASE_URL: postgres://postgres:password@mcaptcha_postgres:5432/postgres # set password at placeholder
-      MCAPTCHA_redis_URL: "redis://mcaptcha_redis/"
-      RUST_LOG: "debug"
-      PORT: 7000
+    env_file:
+      - .env.docker-compose
     depends_on:
       - mcaptcha_postgres
       - mcaptcha_redis


### PR DESCRIPTION
mCaptcha is fully configurable via environment variables. There has been some ambiguity regarding environment variable names, so this patch adds a `.env` file that lists all env vars. It also loads it into docker-compose.