### PR TITLE
fix: an error message

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -77,7 +77,7 @@ pub enum ServiceError {
 
     #[display(fmt = "Passsword too short")]
     PasswordTooShort,
-    #[display(fmt = "Username too long")]
+    #[display(fmt = "Password too long")]
     PasswordTooLong,
     #[display(fmt = "Passwords don't match")]
     PasswordsDontMatch,


### PR DESCRIPTION
Fixed a message that could mislead users.
Also, what is the maximum number of digits for a password?