### PR TITLE
Added automatic dark mode to the widget

### DIFF
--- a/templates/widget/main.scss
+++ b/templates/widget/main.scss
@@ -28,6 +28,8 @@ body {
 	display: flex;
 	height: 100%;
 	width: 100%;
+	background-color: #f6f6f6;
+	border: 2px solid #e5e5e5;
 }
 
 .widget__noscript-container {
@@ -103,6 +105,11 @@ body {
 		background-color: #1c1c1c;
 	}
 
+	.widget__inner-container {
+		background-color: #1c1c1c;
+		border: 2px solid #656569;
+	}
+
 	.widget__verification-container {
 		color: rgb(232, 230, 227);
 	}
@@ -130,4 +137,10 @@ body {
 	border-radius: 15px;
 	height: 100%;
 	width: 0%;
+}
+
+@media (prefers-color-scheme: dark) {
+	.progress__bar {
+		background: unset;
+	}
 }

--- a/templates/widget/main.scss
+++ b/templates/widget/main.scss
@@ -98,6 +98,24 @@ body {
 	margin: 2px;
 }
 
+@media (prefers-color-scheme: dark) {
+	.widget__container {
+		background-color: #1c1c1c;
+	}
+
+	.widget__verification-container {
+		color: rgb(232, 230, 227);
+	}
+
+	.widget__mcaptcha-brand-name {
+		color: #7d94f9;
+	}
+
+	.widget__mcaptcha-info-link {
+		color: #7d94f9;
+	}
+}
+
 /* progress bar courtesy of https://codepen.io/Bizzy-Coding/pen/poOymVJ?editors=1111 */
 .progress__bar {
 	position: relative;


### PR DESCRIPTION
A lot of pages nowadays respect the CSS `prefers-color-scheme` attribute to change the colors of the website automatically based on the users browser or system settings.
As the widget didn't have any CSS logic to respect that and looked quite ugly with the dark mode I added some CSS to make the widget also look good if the user requests the dark mode of a page.
I also adjusted the existing background a bit so that we don't have white-on-white for a normal page.

This is how it will look in dark mode (`prefers-color-scheme: dark`):
![image](https://github.com/mCaptcha/mCaptcha/assets/70581801/d353c65b-a085-4548-9cd3-45c2fec4b829)

And this is how it will look in light mode (`prefers-color-scheme: light`):
![image](https://github.com/mCaptcha/mCaptcha/assets/70581801/4076db25-cb1b-449d-8df8-aa4b83c53efa)
Note that the links are blue as well if not visited before.

If you have any suggestions feel free to write comments.
