### PR TITLE
Update .env.docker-compose to use port 7000 instead of 7001

### DIFF
--- a/.env.docker-compose
+++ b/.env.docker-compose
@@ -13,7 +13,7 @@ MCAPTCHA_redis_URL=redis://mcaptcha_redis
 MCAPTCHA_redis_POOL=4
 
 # server
-PORT=7001
+PORT=7000
 MCAPTCHA_server_DOMAIN=localhost
 MCAPTCHA__server_COOKIE_SECRET=pleasereplacethiswithrandomstring # PLEASE SET RANDOM STRING. MIN LENGTH=32
 MCAPTCHA__server_IP= 0.0.0.0


### PR DESCRIPTION
I'm not sure if theres a reason for .env.docker-compose to use port 7001, but since the readme.md talks about port 7000 and not 7001, and the docker compose forwards 7000 and not 7001, I dont think its supposed to be 7001.