### PR TITLE
fix: SPDX identifier for license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vanilla",
   "main": "index.js",
   "version": "1.0.0",
-  "license": "AGPL-3.0",
+  "license": "AGPL-3.0-or-later",
   "scripts": {
     "build": "webpack --mode production",
     "lint": "yarn run eslint templates",


### PR DESCRIPTION
<https://spdx.org/licenses/> only lists the SPDX identifier `AGPL-3.0` as deprecated. Downstream tooling stopped accepting it. Thus, I argue that the current [value for the `license` is invalid](https://docs.npmjs.com/cli/v6/configuring-npm/package-json#license). Since [`/LICENSES/` contains a file named `AGPL-3.0-or-later.txt`](https://github.com/mCaptcha/mCaptcha/blob/581e6f9440dc229f2f1153f15a80a6099e631fe9/LICENSES/AGPL-3.0-or-later.txt) I assume that `AGPL-3.0-or-later` is the SPDX identifier of the license you mean.